### PR TITLE
fix(cmake): stop disabling MSVC optimizations in Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,10 @@ if(MSVC)
 
   add_definitions(-DHMAP_MSVC)
 
-  add_compile_options(/W4 /Od)
+  # do NOT pass /Od here: add_compile_options lands after the per-config flags
+  # on the MSVC command line, where it overrides Release's /O2 (last flag wins),
+  # silently disabling optimization in every Release build
+  add_compile_options(/W4 "$<$<NOT:$<CONFIG:Debug>>:/fp:fast>")
 
   add_compile_definitions(M_PI=3.14159265358979323846)
 


### PR DESCRIPTION
## What

One-line build fix: the MSVC branch of the root `CMakeLists.txt` passed `/Od` via `add_compile_options`. Those flags land **after** the per-config flags on the cl command line, and MSVC takes the last optimization flag — so `/Od` silently overrode Release's `/O2` (cl does warn: `D9025: overriding '/O2' with '/Od'`, but it scrolls by). Every Windows build of HighMap — including release packaging — has been compiling the entire library with optimizations disabled.

This drops `/Od` so each config's defaults apply (`/O2` Release, `/Od` Debug), and adds `/fp:fast` outside Debug to match the `-ffast-math` the GCC/Clang branches already use.

## Measurements

Windows 11, RTX 5060 (OpenCL), 6 cores, MSVC 14.44 — Hesiod headless batch `--batch data\bootstraps\island.hsd --shape=4096,4096`, 3 runs each:

| build | times |
|---|---|
| before (`/W4 /Od`) | 47.5 / 46.2 / 47.1 s |
| after (`/W4`, `/fp:fast`) | 19.5 / 17.3 / 17.4 s |

**2.7× faster**, and now in line with equivalent-hardware Linux times. This explains the long-standing "Windows is ~3× slower than Linux" observations — it was never OpenCL, just CPU-side codegen.

Note: `/fp:fast` means Windows floating-point output can differ very slightly from previous Windows builds — it aligns Windows with what Linux/macOS builds have always produced under `-ffast-math`. Drop that flag from this PR if you'd rather keep bit-stability with old Windows builds.

The other repos (Attributes, GNodeGUI, QTerrainRenderer, QTextureDownloader) also set `/W4 /Od`, but via `CMAKE_CXX_FLAGS`, which lands *before* the config flags — so `/O2` wins there and they're unaffected. Only HighMap used the `add_compile_options` form.