### PR TITLE
fix(export): allocate texture coordinates in TRI_OPTIMIZED mesh export

### DIFF
--- a/HighMap/src/export/export_asset.cpp
+++ b/HighMap/src/export/export_asset.cpp
@@ -198,6 +198,9 @@ void helper_build_mesh(aiMesh      *p_mesh,
     p_mesh->mVertices = new aiVector3D[n_vertices];
     p_mesh->mNumVertices = n_vertices;
 
+    p_mesh->mTextureCoords[0] = new aiVector3D[n_vertices];
+    p_mesh->mNumUVComponents[0] = 2;
+
     for (size_t k = 0; k < points.size(); k++)
     {
       p_mesh->mVertices[k] = aiVector3D(ay * points[k].y,

--- a/tests/src/test_export_asset.cpp
+++ b/tests/src/test_export_asset.cpp
@@ -1,0 +1,62 @@
+#include <cstdio>
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "highmap.hpp"
+
+using namespace hmap;
+
+// Regression: the TRI_OPTIMIZED (Delaunay) mesh path wrote texture
+// coordinates into an unallocated aiMesh::mTextureCoords[0] -> SIGSEGV.
+TEST(ExportAsset, TriOptimizedExportsWithoutCrash)
+{
+  glm::ivec2 shape = {64, 64};
+  Array      z = noise(NoiseType::SIMPLEX2, shape, {2.f, 2.f}, 1);
+  remap(z);
+
+  std::filesystem::path fname = std::filesystem::temp_directory_path() /
+                                "hmap_test_tri_optimized";
+
+  // export_asset appends the format extension itself
+  std::filesystem::path out = fname.string() + ".glb";
+
+  bool ok = export_asset(fname.string(),
+                         z,
+                         MeshType::TRI_OPTIMIZED,
+                         AssetExportFormat::GLB2,
+                         0.2f,
+                         "",
+                         "",
+                         1e-2f);
+
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(std::filesystem::exists(out));
+  std::filesystem::remove(out);
+}
+
+TEST(ExportAsset, TriExportsWithoutCrash)
+{
+  glm::ivec2 shape = {64, 64};
+  Array      z = noise(NoiseType::SIMPLEX2, shape, {2.f, 2.f}, 1);
+  remap(z);
+
+  std::filesystem::path fname = std::filesystem::temp_directory_path() /
+                                "hmap_test_tri";
+
+  // export_asset appends the format extension itself
+  std::filesystem::path out = fname.string() + ".glb";
+
+  bool ok = export_asset(fname.string(),
+                         z,
+                         MeshType::TRI,
+                         AssetExportFormat::GLB2,
+                         0.2f,
+                         "",
+                         "",
+                         1e-2f);
+
+  EXPECT_TRUE(ok);
+  EXPECT_TRUE(std::filesystem::exists(out));
+  std::filesystem::remove(out);
+}


### PR DESCRIPTION
Closes #436

## Problem

`export_asset()` with `MeshType::TRI_OPTIMIZED` segfaults on every call. The Delaunay branch of `helper_build_mesh()` writes `p_mesh->mTextureCoords[0][k]` for each vertex but never allocates `mTextureCoords[0]`, so the first write dereferences null. Full analysis, crash trace and core-dump registers are in #436.

In Hesiod this crashes the whole application when an ExportAsset node runs with the optimized mesh type.

## Fix

Allocate the UV array in the `TRI_OPTIMIZED` branch exactly as the `TRI` branch (and `helper_build_mesh_masked()`) already do:

```cpp
p_mesh->mTextureCoords[0] = new aiVector3D[n_vertices];
p_mesh->mNumUVComponents[0] = 2;
```

## Test

New `tests/src/test_export_asset.cpp` exports a 64x64 array to glb with both `TRI` and `TRI_OPTIMIZED` and checks the return value and output file.

- Before the fix: `ExportAsset.TriOptimizedExportsWithoutCrash` segfaults (exit 139) right after the "remeshing (Delaunay)" trace.
- After the fix: both tests pass (verified on this branch rebased on `dev`, Linux, Release).
