### PR TITLE
chore: use https URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,34 +1,34 @@
 [submodule "external/FastNoiseLite"]
 	path = external/FastNoiseLite
-	url = git@github.com:Auburn/FastNoiseLite.git
+	url = https://github.com/Auburn/FastNoiseLite.git
 	ignore = untracked
 [submodule "external/dkm"]
 	path = external/dkm
-	url = git@github.com:genbattle/dkm.git
+	url = https://github.com/genbattle/dkm.git
 [submodule "external/hmm"]
 	path = external/hmm
-	url = git@github.com:fogleman/hmm.git
+	url = https://github.com/fogleman/hmm.git
 [submodule "external/Noise"]
 	path = external/Noise
-	url = git@github.com:otto-link/Noise.git
+	url = https://github.com/otto-link/Noise.git
 [submodule "external/libnpy"]
 	path = external/libnpy
-	url = git@github.com:llohse/libnpy.git
+	url = https://github.com/llohse/libnpy.git
 [submodule "external/CLWrapper"]
 	path = external/CLWrapper
-	url = git@github.com:ottolink-dev/CLWrapper.git
+	url = https://github.com/ottolink-dev/CLWrapper.git
 [submodule "external/PointSampler"]
 	path = external/PointSampler
-	url = git@github.com:otto-link/PointSampler.git
+	url = https://github.com/otto-link/PointSampler.git
 [submodule "external/nn-c"]
 	path = external/nn-c
-	url = git@github.com:sakov/nn-c.git
+	url = https://github.com/sakov/nn-c.git
 [submodule "external/nanoflann"]
 	path = external/nanoflann
 	url = https://github.com/jlblancoc/nanoflann.git
 [submodule "external/terrain-descriptors"]
 	path = external/terrain-descriptors
-	url = git@github.com:otto-link/terrain-descriptors.git
+	url = https://github.com/otto-link/terrain-descriptors.git
 [submodule "external/mixbox"]
 	path = external/mixbox
 	url = https://github.com/scrtwpns/mixbox.git


### PR DESCRIPTION
Switch the 9 remaining SSH submodule URLs to https (nanoflann and mixbox already were). Also bumps the CLWrapper pin to the commit carrying its own URL change (ottolink-dev/CLWrapper PR); that pin will be updated to the merged commit once it lands.

SSH URLs need a GitHub account with a registered key just to clone recursively, which breaks anonymous consumers: Nix flakes, Flatpak builders, CI without secrets, Windows setups without an ssh agent. https clones anonymously everywhere.

Nothing changes for pushing:
- existing clones keep their current URLs until `git submodule sync --recursive` is run;
- fresh clones push over SSH with one global rule: `git config --global url."git@github.com:".pushInsteadOf "https://github.com/"`.

Part of a five-repo change (CLWrapper, HighMap, GNode, QTerrainRenderer, Hesiod) so a recursive clone of Hesiod works without SSH. Merge order: CLWrapper → HighMap → GNode, QTerrainRenderer → Hesiod.
